### PR TITLE
Fix the broken nix build, add a CI job to ensure it stays working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  nix-build:
+    name: Nix Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Verify Nix build
+        run: nix build .#default -L

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
           src = ./.;
 
           # Run: nix build .#default 2>&1 | grep "got:" to get real hash
-          vendorHash = "sha256-hOmeXm6ym+9gBKwSxLovlry0jLCcfZYpxb/Kzt2DUQg=";
+          vendorHash = "sha256-fLSnn+MekmCZQJh7NCJmHdUXOK5QnRsvUfvyXZr5QyQ=";
 
           # Native dependencies (none needed - all drivers are pure Go)
 


### PR DESCRIPTION
The `go.mod` got updated recently but the vendorHash didn't. I'm installing squix from `main` using nix so it broke my daily updates (not a big deal) which is why I noticed.