### PR TITLE
fix error if select statement contains distinct

### DIFF
--- a/internal/db/sqlserver_connection.go
+++ b/internal/db/sqlserver_connection.go
@@ -432,6 +432,11 @@ func (s *SQLServerConnection) ApplyRowLimit(sql string, limit int) string {
 		return sql
 	}
 
+ 	// Don't apply row limit if select-statement contains distinct
+	if strings.Contains(trimmedSQL, "DISTINCT") {
+		return sql
+	}
+
 	upperSQL := strings.ToUpper(sql)
 
 	if strings.Contains(upperSQL, " TOP ") {


### PR DESCRIPTION
for sqlserver `ApplyRowLimit` generates an invalid select statement (`SELECT TOP 1000 DISTINCT ...`), if it contains `DISTINCT`. 

```bash
./squix run "select distinct name from sys.tables"
✗ Error: query execution failed: mssql: Incorrect syntax near the keyword 'distinct'.
```

This is the fix.