### PR TITLE
feat: add CSV file viewing to explore command

### DIFF
--- a/cmd/squix/explore.go
+++ b/cmd/squix/explore.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/csv"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -10,11 +12,23 @@ import (
 	"github.com/eduardofuncao/squix/internal/db"
 	"github.com/eduardofuncao/squix/internal/run"
 	"github.com/eduardofuncao/squix/internal/styles"
+	"github.com/eduardofuncao/squix/internal/table"
 )
 
 func (a *App) handleExplore() {
 	if len(os.Args) < 3 {
 		a.listTablesAndViews()
+		return
+	}
+
+	// Check if argument is a supported file type
+	if ext, ok := getSupportedExtension(os.Args[2]); ok {
+		if _, err := os.Stat(os.Args[2]); err != nil {
+			printError("File not found: %s", os.Args[2])
+		}
+		if err := a.handleExploreFile(os.Args[2], ext); err != nil {
+			printError("%v", err)
+		}
 		return
 	}
 
@@ -160,4 +174,72 @@ func (a *App) formatTableList(items []string) {
 	if len(items)%numColumns != 0 {
 		fmt.Println()
 	}
+}
+
+var supportedFileTypes = map[string]bool{
+	".csv": true,
+	// ".json": true, // Future support
+}
+
+func getSupportedExtension(arg string) (string, bool) {
+	ext := strings.ToLower(filepath.Ext(arg))
+	if supported, ok := supportedFileTypes[ext]; ok && supported {
+		return ext, true
+	}
+	return "", false
+}
+
+func parseCSV(path string) (columns []string, data [][]string, err error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not open CSV file: %w", err)
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	reader.LazyQuotes = true
+	reader.TrimLeadingSpace = true
+
+	// Read header row
+	columns, err = reader.Read()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read CSV header: %w", err)
+	}
+
+	// Read data rows
+	data, err = reader.ReadAll()
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not read CSV data: %w", err)
+	}
+
+	return columns, data, nil
+}
+
+func (a *App) handleExploreFile(path string, ext string) error {
+	columns, data, err := parseCSV(path)
+	if err != nil {
+		return err
+	}
+
+	// Render table with nil connection (read-only mode)
+	columnTypes := make([]string, len(columns))
+	_, err = table.Render(
+		columns,
+		columnTypes,
+		data,
+		0, // elapsed time
+		nil, // no database connection
+		"", // no table name
+		"", // no primary key
+		db.Query{}, // empty query
+		a.config.DefaultColumnWidth,
+		a.config.UIVisibility,
+		a.config.KeyMap, // use config keybindings if available
+		nil, // no save callback
+	)
+	if err != nil {
+		return fmt.Errorf("could not render table: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/squix/help.go
+++ b/cmd/squix/help.go
@@ -523,13 +523,14 @@ func (a *App) PrintCommandHelp() {
 		section("Command: explore")
 		fmt.Println(
 			styles.Faint.Render(
-				"Explore your database schema and query tables interactively.",
+				"Explore your database schema and query tables interactively, or view CSV files.",
 			),
 		)
 		fmt.Println()
 		section("Usage")
 		fmt.Println("  squix explore")
 		fmt.Println("  squix explore <table> [--limit | -l N]")
+		fmt.Println("  squix explore <file.csv>")
 		fmt.Println()
 		section("Description")
 		fmt.Println(
@@ -539,6 +540,9 @@ func (a *App) PrintCommandHelp() {
 			"  With a table name, queries the table and shows results in an",
 		)
 		fmt.Println("  interactive table view (similar to 'squix run').")
+		fmt.Println(
+			"  With a file path, opens CSV files in read-only mode (no database connection required).",
+		)
 		fmt.Println()
 		fmt.Println(
 			"  --limit, -l N  " + styles.Faint.Render(
@@ -550,6 +554,7 @@ func (a *App) PrintCommandHelp() {
 		fmt.Println("  squix explore                  # list all tables and views")
 		fmt.Println("  squix explore employees        # query employees table")
 		fmt.Println("  squix explore orders -l 50     # query with 50 row limit")
+		fmt.Println("  squix explore data.csv         # view CSV file")
 
 	case "explain":
 		section("Command: explain")

--- a/internal/table/delete_row.go
+++ b/internal/table/delete_row.go
@@ -138,6 +138,10 @@ func (m Model) handleDeleteComplete(msg deleteCompleteMsg) (tea.Model, tea.Cmd) 
 }
 
 func (m Model) buildDeleteStatement() string {
+	if m.dbConnection == nil {
+		return ""
+	}
+
 	pkValue := ""
 	var multipleMatches bool
 
@@ -168,6 +172,10 @@ func (m Model) buildDeleteStatement() string {
 }
 
 func (m Model) executeDelete(sql string) error {
+	if m.dbConnection == nil {
+		return fmt.Errorf("no database connection")
+	}
+
 	var result strings.Builder
 	for line := range strings.SplitSeq(sql, "\n") {
 		trimmed := strings.TrimSpace(line)

--- a/internal/table/export.go
+++ b/internal/table/export.go
@@ -182,10 +182,14 @@ func (m Model) executeExportForFormat(key string) (Model, tea.Cmd) {
 func (m Model) formatExportContent(headers []string, rows [][]string, format exportFormat) (string, error) {
 	opts := FormatOptions{
 		QueryName: m.currentQuery.Name,
-		DbType:    m.dbConnection.GetDbType(),
-		DbName:    m.dbConnection.GetName(),
 		TableName: m.tableName,
 	}
+
+	if m.dbConnection != nil {
+		opts.DbType = m.dbConnection.GetDbType()
+		opts.DbName = m.dbConnection.GetName()
+	}
+
 	return FormatExport(headers, rows, string(format), opts)
 }
 

--- a/internal/table/navigation.go
+++ b/internal/table/navigation.go
@@ -243,6 +243,10 @@ func (m Model) showDetailView() Model {
 }
 
 func (m Model) editFromDetailView() (Model, tea.Cmd) {
+	if m.dbConnection == nil {
+		return m, nil
+	}
+
 	if m.selectedRow < 0 || m.selectedRow >= len(m.data) ||
 		m.selectedCol < 0 || m.selectedCol >= len(m.data[m.selectedRow]) {
 		return m, nil

--- a/internal/table/update_cell.go
+++ b/internal/table/update_cell.go
@@ -126,6 +126,10 @@ func (m Model) blinkCmd() tea.Cmd {
 }
 
 func (m Model) buildUpdateStatement() string {
+	if m.dbConnection == nil {
+		return ""
+	}
+
 	columnName := m.columns[m.selectedCol]
 	currentValue := m.data[m.selectedRow][m.selectedCol]
 
@@ -162,6 +166,10 @@ func (m Model) buildUpdateStatement() string {
 }
 
 func (m Model) fetchPrimaryKeyValue() (string, bool) {
+	if m.dbConnection == nil {
+		return "", false
+	}
+
 	if m.primaryKeyCol == "" || m.tableName == "" {
 		return "", false
 	}
@@ -214,6 +222,10 @@ func escapeSQLValue(val string) string {
 }
 
 func (m Model) executeUpdate(sql string) error {
+	if m.dbConnection == nil {
+		return fmt.Errorf("no database connection")
+	}
+
 	var result strings.Builder
 	for line := range strings.SplitSeq(sql, "\n") {
 		trimmed := strings.TrimSpace(line)


### PR DESCRIPTION
Hii, basically squix has the best and most simple table rendering I could ever want so I expanded the explore command to take direct file paths as argument to render tables as one-shot connection. I basically re-used the backend and wired to the command endpoint.

Currently it supports csv but actually do need quick viewing .db files so I might add it as well since the whole backend is already there.

## Summary

Adds CSV file viewing capability to the `squix explore` command, allowing users to view CSV files in the interactive table viewer without requiring a database connection.

## Changes

- **CSV parsing**: Added CSV file detection and parsing in `cmd/squix/explore.go`
- **Read-only mode**: Implemented nil-safe database operations in table viewer
  - Added nil checks in `delete_row.go`, `navigation.go`, `update_cell.go`, `export.go`
  - Prevents write operations when no database connection exists
- **Documentation**: Updated help text with CSV viewing examples
- **Compatibility**: Fixed `table.Render()` call to include new `KeyMap` parameter from recent keybindings feature

## Usage

```bash
squix explore data.csv
```

The CSV file opens in read-only mode with full table navigation (vim-style keybindings), search, and export capabilities.

## Testing

- All existing tests pass
- Integration tests successful
- Compatible with recent keybindings feature (#27)

